### PR TITLE
Changed poll processing to save and use the correct order of users

### DIFF
--- a/src/main/java/Discord/API/ServerInteractions.java
+++ b/src/main/java/Discord/API/ServerInteractions.java
@@ -6,6 +6,7 @@ import sx.blah.discord.api.internal.json.objects.EmbedObject;
 import sx.blah.discord.handle.impl.obj.ReactionEmoji;
 import sx.blah.discord.handle.impl.obj.Webhook;
 import sx.blah.discord.handle.obj.IChannel;
+import sx.blah.discord.handle.obj.IEmbed;
 import sx.blah.discord.handle.obj.IMessage;
 import sx.blah.discord.handle.obj.IReaction;
 import sx.blah.discord.handle.obj.IUser;
@@ -59,6 +60,13 @@ public class ServerInteractions {
 		RequestBuffer.request(() -> {
 			message.edit(embed);
 		});
+	}
+	
+	public static IEmbed getEmbedInMessage(IMessage message, int embedID) {
+		IEmbed result = RequestBuffer.request(() -> {
+			return message.getEmbeds().get(embedID);
+		}).get();
+		return result;
 	}
 	
 	public static boolean addReactionToMessage(IMessage message, ReactionEmoji reaction) {

--- a/src/main/java/Wrappers/EmbedWrapper.java
+++ b/src/main/java/Wrappers/EmbedWrapper.java
@@ -1,5 +1,6 @@
 package Wrappers;
 
+import java.util.List;
 import java.util.Map;
 
 import Discord.Constants;
@@ -58,16 +59,16 @@ public class EmbedWrapper {
 		return CreateFirstPollMessage(author, guild, content, type, author.getDisplayName(guild)+Constants.POLL_ADDITION);
 	}
 	
-	public EmbedObject createNewPollEmbedFromPrevious(Map<Long,IUser> usersYes, Map<Long,IUser> usersNo, IGuild guild) {
+	public EmbedObject createNewPollEmbedFromPrevious(List<Long> usersYes, List<Long> usersNo, IGuild guild) {
 	    
 	    // Build strings for voters
 	    String peopleYes = "";
 	    String peopleNo = "";
 	    
-	    for(Map.Entry<Long, IUser> u:usersYes.entrySet())
-	    	peopleYes = peopleYes + u.getValue().getDisplayName(guild) + "\n";
-	    for(Map.Entry<Long, IUser> u:usersNo.entrySet())
-	    	peopleNo = peopleNo + u.getValue().getDisplayName(guild) + "\n";
+	    for(Long l : usersYes)
+	    	peopleYes = peopleYes + "<@" + String.valueOf(l) + ">\n";
+	    for(Long l : usersNo)
+	    	peopleNo = peopleNo + "<@" + String.valueOf(l) + ">\n";
 	    
 	    if(usersYes.isEmpty()) peopleYes = "-----";
 	    if(usersNo.isEmpty()) peopleNo = "-----";
@@ -89,4 +90,6 @@ public class EmbedWrapper {
 	    
 	    return builder.build();
 	}
+	
+	//public String returnEmbedContent()
 }


### PR DESCRIPTION
I changed the text of the embed to use not the name but the user-id. This means that the name is always correct for the server and is also a link which can be used to e.g. write the user a direct message. This allows us to read the ID from the embed and use the embed as 'database'. New users are added to the end, if there are multiple users at once the order of discord4j is used as sort of random choice.

You can pull this branch and test it with your dev-bot at first.